### PR TITLE
Add All Shows section

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,12 +1,13 @@
 ART = 'art-default.jpg'
 ICON = 'icon-default.jpg'
 
-SHOWS_URL = 'http://www.cbs.com/shows/%s/'
+SHOWS_URL = 'http://www.cbs.com/shows/%s'
 SECTION_CAROUSEL = 'http://www.cbs.com/carousels/videosBySection/%s/offset/0/limit/40/xs/0'
 CATEGORIES = [
     {'category_id': 'primetime', 'title': 'Primetime'},
     {'category_id': 'daytime', 'title': 'Daytime'},
-    {'category_id': 'late-night', 'title': 'Late Night'}
+    {'category_id': 'late-night', 'title': 'Late Night'},
+    {'category_id': ' ', 'title': 'All Shows'}
 ]
 
 RE_SECTION_IDS = Regex('(?:video\.section_ids = |"section_ids"\:)\[([^\]]+)\]')


### PR DESCRIPTION
Updated code to include an all shows section to catch any shows not listed in the existing categories. It appears that the classic show episodes that are included in the All Shows listing play fine (those that show up in the channel listing are only those that play on their website and do not require CBS All Access). I tried a few random shows and they played for me.